### PR TITLE
Token Cache Enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Tokens was initially developed for use in my private server, the idea was to giv
 -   **[CombatLogX](https://www.spigotmc.org/resources/combatlogx.31689/)**
 -   **[PlaceholderAPI](https://www.spigotmc.org/resources/placeholderapi.6245/)**
 -   **[Any Vault Economy](https://www.spigotmc.org/resources/vault.34315/)**
+-   **[Prison](https://www.spigotmc.org/resources/prison.1223/history/)**
 
 Want a plugin on this list? Let me know  [here](https://github.com/TheCoolestPaul/Tokens/issues), make sure to include a link to the plugin, what a token should be spent on, and any information you think I'll need to add it.​
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.9.13-alpha.3
-version=3.9.9.1
+version=3.9.9.2
 
 ## org.gradle.warning.mode=(all,none,summary)
 org.gradle.warning.mode=all

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.9.13-alpha.3
-version=3.9.8-blue.1
+version=3.9.8-blue.2
 
 ## org.gradle.warning.mode=(all,none,summary)
 org.gradle.warning.mode=all

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.9.13-alpha.3
-version=3.9.9.4
+version=3.9.9.5
 
 ## org.gradle.warning.mode=(all,none,summary)
 org.gradle.warning.mode=all

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.9.13-alpha.3
-version=3.9.9.3
+version=3.9.9.4
 
 ## org.gradle.warning.mode=(all,none,summary)
 org.gradle.warning.mode=all

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.9.13-alpha.3
-version=3.9.9.2
+version=3.9.9.3
 
 ## org.gradle.warning.mode=(all,none,summary)
 org.gradle.warning.mode=all

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.9.13-alpha.3
-version=3.9.8-blue.2
+version=3.9.8-blue.3
 
 ## org.gradle.warning.mode=(all,none,summary)
 org.gradle.warning.mode=all

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.9.13-alpha.3
-version=3.9.9
+version=3.9.9.1
 
 ## org.gradle.warning.mode=(all,none,summary)
 org.gradle.warning.mode=all

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 ## # This is actually the "correct" place to define the version for the project.
 ## # Used within build.gradle with ${project.version}.
 ## # Can be overridden on the command line: gradle -Pversion=3.9.13-alpha.3
-version=3.9.8-blue.3
+version=3.9.8-blue.4
 
 ## org.gradle.warning.mode=(all,none,summary)
 org.gradle.warning.mode=all

--- a/src/main/java/net/thirdshift/tokens/Tokens.java
+++ b/src/main/java/net/thirdshift/tokens/Tokens.java
@@ -1,6 +1,7 @@
 package net.thirdshift.tokens;
 
 import net.milkbowl.vault.economy.Economy;
+import net.thirdshift.tokens.cache.TokenCache;
 import net.thirdshift.tokens.commands.redeem.RedeemCommandExecutor;
 import net.thirdshift.tokens.commands.redeem.redeemcommands.KeyRedeemModule;
 import net.thirdshift.tokens.commands.tokens.CommandTokens;
@@ -77,6 +78,8 @@ public final class Tokens extends JavaPlugin {
 
 		redeemCommandExecutor = new RedeemCommandExecutor(this);
 
+		TokenCache.initialize( this );
+		
 		new BStats(this, 5849);
 
 		this.workCommands();
@@ -130,6 +133,9 @@ public final class Tokens extends JavaPlugin {
 
 	@Override
 	public void onDisable() {
+		
+		TokenCache.onDisable();
+		
 		keyHander.saveKeyCooldown();
 		instance = null;
 		if(tokensConfigHandler.isRunningMySQL()){

--- a/src/main/java/net/thirdshift/tokens/Tokens.java
+++ b/src/main/java/net/thirdshift/tokens/Tokens.java
@@ -138,8 +138,15 @@ public final class Tokens extends JavaPlugin {
 		
 		keyHander.saveKeyCooldown();
 		instance = null;
+		
+		// The database connections are shutdown in TokenCacheDatabase but
+		// providing final attempts here just to ensure they are shutdown to
+		// help prevent corruption.
 		if(tokensConfigHandler.isRunningMySQL()){
-			mysql.stopSQLConnection();//Cut off any loose bois
+			mysql.closeConnection();//Cut off any loose bois
+		}
+		else {
+			sqllite.closeConnection();
 		}
 	}
 
@@ -251,7 +258,7 @@ public final class Tokens extends JavaPlugin {
 		if(this.mysql==null) {
 			this.mysql = new MySQLHandler(this);
 		}else{
-			this.mysql.stopSQLConnection();
+			this.mysql.closeConnection();
 			this.getLogger().info("Closing old MySQL connection.");
 		}
 		this.mysql.updateSettings();

--- a/src/main/java/net/thirdshift/tokens/TokensHandler.java
+++ b/src/main/java/net/thirdshift/tokens/TokensHandler.java
@@ -1,7 +1,8 @@
 package net.thirdshift.tokens;
 
-import net.thirdshift.tokens.util.TokensConfigHandler;
 import org.bukkit.entity.Player;
+
+import net.thirdshift.tokens.cache.TokenCache;
 
 //import java.util.HashMap;
 //import java.util.Map;
@@ -15,14 +16,15 @@ MySQL or SQLLite.
 
 public class TokensHandler {
 
-    private final Tokens plugin;
-    private final TokensConfigHandler configHandler;
+//    private final Tokens plugin;
+//    private final TokensConfigHandler configHandler;
     //private Map<UUID, Integer> playerBalances;
-
+    
     public TokensHandler(final Tokens instance){
-        this.plugin=instance;
-        configHandler = instance.getTokensConfigHandler();
+//        this.plugin=instance;
+//        configHandler = instance.getTokensConfigHandler();
         //playerBalances = new HashMap<>();
+        
     }
 
     /**
@@ -31,11 +33,12 @@ public class TokensHandler {
      * @param tokensIn Amount of tokens
      */
     public void addTokens(Player player, int tokensIn){
-        if(configHandler.isRunningMySQL()){
-            plugin.getMySQL().addTokens(player, tokensIn);
-        } else {
-            plugin.getSqllite().addTokens(player, tokensIn );
-        }
+    	TokenCache.getInstance().addTokens( player, tokensIn );
+//        if(configHandler.isRunningMySQL()){
+//            plugin.getMySQL().addTokens(player, tokensIn);
+//        } else {
+//            plugin.getSqllite().addTokens(player, tokensIn );
+//        }
     }
 
     /**
@@ -44,11 +47,12 @@ public class TokensHandler {
      * @return Current balance of Player's tokens
      */
     public int getTokens(Player player){
-        if(configHandler.isRunningMySQL()){
-            return plugin.getMySQL().getTokens(player);
-        }else {
-            return plugin.getSqllite().getTokens(player);
-        }
+    	return TokenCache.getInstance().getTokens( player );
+//        if(configHandler.isRunningMySQL()){
+//            return plugin.getMySQL().getTokens(player);
+//        }else {
+//            return plugin.getSqllite().getTokens(player);
+//        }
     }
 
     /**
@@ -57,11 +61,12 @@ public class TokensHandler {
      * @param tokensIn Tokens to set
      */
     public void setTokens(Player player, int tokensIn){
-        if(configHandler.isRunningMySQL()){
-            plugin.getMySQL().setTokens(player, tokensIn);
-        }else {
-            plugin.getSqllite().setTokens(player, tokensIn);
-        }
+    	TokenCache.getInstance().setTokens( player, tokensIn );
+//        if(configHandler.isRunningMySQL()){
+//            plugin.getMySQL().setTokens(player, tokensIn);
+//        }else {
+//            plugin.getSqllite().setTokens(player, tokensIn);
+//        }
     }
 
     /**
@@ -70,11 +75,12 @@ public class TokensHandler {
      * @param tokensIn Tokens to remove
      */
     public void removeTokens(Player player, int tokensIn){
-        if(configHandler.isRunningMySQL()){
-            plugin.getMySQL().removeTokens(player, tokensIn);
-        }else {
-            plugin.getSqllite().setTokens( player, (plugin.getSqllite().getTokens(player) - tokensIn) );
-        }
+    	TokenCache.getInstance().removeTokens( player, tokensIn );
+//        if(configHandler.isRunningMySQL()){
+//            plugin.getMySQL().removeTokens(player, tokensIn);
+//        }else {
+//            plugin.getSqllite().setTokens( player, (plugin.getSqllite().getTokens(player) - tokensIn) );
+//        }
     }
 
     /**
@@ -84,7 +90,8 @@ public class TokensHandler {
      * @return True if player has tokens, false player does not have enough tokens
      */
     public boolean hasTokens(Player player, int tokensIn){
-        return getTokens(player) >= tokensIn;
+    	return TokenCache.getInstance().hasTokens( player, tokensIn );
+//        return getTokens(player) >= tokensIn;
     }
 
 }

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCache.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCache.java
@@ -115,6 +115,7 @@ public class TokenCache {
 	 */
 	public static void onDisable() {
 		getInstance().onDisableInternal();
+		
 	}
 	
 	/**
@@ -188,6 +189,10 @@ public class TokenCache {
 			}
 			
 		}
+		
+		// Shutdown the database connections:
+		getCacheDatabase().closeConnections();
+		
 	}
 
 	

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCache.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCache.java
@@ -30,6 +30,8 @@ public class TokenCache {
 	private long writeDelay = 0L;
 	
 	private TokenCacheStats stats;
+	private boolean journal;
+	private String journalPlayer;
 
 	
 	private Map<UUID, TokenCachePlayerData> players;
@@ -401,7 +403,46 @@ public class TokenCache {
 	public void setStats( TokenCacheStats stats ) {
 		this.stats = stats;
 	}
+	
+	
+	public boolean isJournal() {
+		return journal;
+	}
+	public void setJournal( boolean journal ) {
+		this.journal = journal;
+	}
+	public boolean toggleJournal() {
+		return this.journal = !this.journal;
+	}
+	
+	public String getJournalPlayer() {
+		return journalPlayer;
+	}
+	public void setJournalPlayer( String journalPlayer ){
+		this.journalPlayer = journalPlayer;
+	}
 
+	void journal( TokenCachePlayerData playerData, String message )
+	{
+		if ( isJournal() && (
+				getJournalPlayer() == null || 
+				getJournalPlayer().equalsIgnoreCase( playerData.getPlayer().getName() ) )) {
+			log( message + (playerData != null ? playerData.toString() : "") );
+		}
+	}
+	private void journal( Player player, String message )
+	{
+		if ( isJournal() && (
+				getJournalPlayer() == null || 
+				getJournalPlayer().equalsIgnoreCase( player.getName() ) )) {
+			log( message + (player != null ? player.getName() : "") );
+		}
+	}
+
+	protected void log( String message ) {
+		getPlugin().getLogger().info( message );
+	}
+	
 	protected Tokens getPlugin() {
 		return plugin;
 	}

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCache.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCache.java
@@ -9,6 +9,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
 
+import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
@@ -127,7 +128,7 @@ public class TokenCache {
 	 * </p>
 	 * 
 	 * <p>This function runs all database transactions synchronously so as to 
-	 * ensure all data is writted to the database before the server is 
+	 * ensure all data is written to the database before the server is 
 	 * terminated.
 	 * </p>
 	 * 
@@ -247,6 +248,8 @@ public class TokenCache {
 		TokenCachePlayerData playerData = new TokenCachePlayerData( player );
 		
 		getPlayers().put( player.getUniqueId(), playerData );
+		getPlayerStrings().put( player.getUniqueId().toString(), playerData );
+		
 		
 		submitAsyncLoadPlayer( playerData );
 		
@@ -286,9 +289,12 @@ public class TokenCache {
 		
 	}
 	
-	protected void submitAsyncSynchronizePlayers() {
+	public void submitAsyncSynchronizePlayers() {
+		submitAsyncSynchronizePlayers( null );
+	}
+	public void submitAsyncSynchronizePlayers( CommandSender commandSender ) {
 		
-		TokenCacheSynchronizeCacheTask task = new TokenCacheSynchronizeCacheTask();
+		TokenCacheSynchronizeCacheTask task = new TokenCacheSynchronizeCacheTask( commandSender );
 		getPlugin().getServer().getScheduler().runTaskLaterAsynchronously( 
 										getPlugin(), task, 0 );
 		

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCache.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCache.java
@@ -444,6 +444,7 @@ public class TokenCache {
 	{
 		if ( isJournal() && (
 				getJournalPlayer() == null || 
+				playerData != null &&
 				getJournalPlayer().equalsIgnoreCase( playerData.getPlayer().getName() ) )) {
 			log( message + (playerData != null ? playerData.toString() : "") );
 		}
@@ -452,6 +453,7 @@ public class TokenCache {
 	{
 		if ( isJournal() && (
 				getJournalPlayer() == null || 
+				player != null &&
 				getJournalPlayer().equalsIgnoreCase( player.getName() ) )) {
 			log( message + (player != null ? player.getName() : "") );
 		}

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCache.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCache.java
@@ -51,25 +51,19 @@ public class TokenCache {
 		
 		this.tasks = new HashMap<>();
 		
-//		this.usersDirty = new ArrayList<>();
-		
 		this.stats = new TokenCacheStats();
 
 	}
 	
 	public static TokenCache getInstance() {
-		if ( instance == null ) {
-			synchronized( TokenCache.class ) {
-				if ( instance == null ) {
-					instance = new TokenCache();
-				}
-			}
-		}
 		return instance;
 	}
 
-	public static void initialize( Tokens plugin ) {
-		getInstance().internalInititalize( plugin );
+	public synchronized static void initialize( Tokens plugin ) {
+		if ( instance == null ) {
+			instance = new TokenCache();
+			instance.internalInititalize( plugin );
+		}
 	}
 	
 	private void internalInititalize( Tokens plugin ) {

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCache.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCache.java
@@ -1,0 +1,365 @@
+package net.thirdshift.tokens.cache;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitTask;
+
+import net.thirdshift.tokens.Tokens;
+
+public class TokenCache {
+	
+	public static final String TOKEN_CACHE_IS_ENABLED = "tokencache.is_enabled";
+	public static final String TOKEN_CACHE_WRITE_DELAY = "tokencache.write_delay";
+	public static final long TOKEN_CACHE_WRITE_DELAY_VALUE_MS = 10000; // 10 seconds
+	public static final String TOKEN_CACHE_TIME_TO_LIVE = "tokencache.time_to_live";
+	public static final long TOKEN_CACHE_TIME_TO_LIVE_VALUE_MS = 30 * 60 * 1000; // 30 mins
+	
+	private static TokenCache instance;
+	
+	private boolean enabled = false;
+	private long writeDelay = 0L;
+	
+	
+	private Map<UUID, TokenCachePlayerData> players;
+//	private List<TokenCacheUser> usersDirty;
+	
+	private Map<BukkitTask, TokenCachePlayerData> tasks;
+	
+	private TokenCacheDatabase cacheDatabase;
+
+	private Tokens plugin;
+	
+	private TokenCache() {
+		super();
+		
+		this.players = new HashMap<>();
+		this.tasks = new HashMap<>();
+		
+//		this.usersDirty = new ArrayList<>();
+
+	}
+	
+	public static TokenCache getInstance() {
+		if ( instance == null ) {
+			synchronized( TokenCache.class ) {
+				if ( instance == null ) {
+					instance = new TokenCache();
+				}
+			}
+		}
+		return instance;
+	}
+
+	public static void initialize( Tokens plugin ) {
+		TokenCache cache = getInstance();
+		cache.setPlugin( plugin );
+		
+		cache.cacheDatabase = new TokenCacheDatabase( cache );
+
+		
+		FileConfiguration config = plugin.getConfig();
+
+		TokenCacheEvents cacheEvents = new TokenCacheEvents();
+		plugin.getServer().getPluginManager().registerEvents(cacheEvents, plugin);
+		
+		boolean dirty = false;
+		
+		// If cache entries do not exist in the config file, then add them:
+		if ( !config.contains( TOKEN_CACHE_IS_ENABLED ) ) {
+			config.addDefault( TOKEN_CACHE_IS_ENABLED, false );
+			dirty = true;
+		}
+		
+		if ( !config.contains( TOKEN_CACHE_WRITE_DELAY ) ) {
+			config.addDefault( TOKEN_CACHE_WRITE_DELAY, TOKEN_CACHE_WRITE_DELAY_VALUE_MS );
+			dirty = true;
+		}
+		
+		if ( dirty ) {
+			cache.getPlugin().saveConfig();
+		}
+
+		// Load settings from config:
+		cache.setEnabled( config.isBoolean( TOKEN_CACHE_IS_ENABLED ));
+		cache.setWriteDelay( config.getLong( TOKEN_CACHE_WRITE_DELAY ) );
+
+		cache.getPlugin().getLogger().info( "### @@@ TokenCache: @@@ ### " + 
+				TOKEN_CACHE_IS_ENABLED + ": " + cache.isEnabled() + " (" +
+				config.isBoolean( TOKEN_CACHE_IS_ENABLED ) + ")  " +
+				"  " + TOKEN_CACHE_WRITE_DELAY + ": " + cache.getWriteDelay() + 
+				" (" + config.getLong( TOKEN_CACHE_WRITE_DELAY ) + ")" );
+	}
+	
+	/**
+	 * <p>The plugin is shutting down so flush all dirty cache items, but first
+	 * disable the caching so as any changes are passed through directly to the
+	 * database.
+	 * </p>
+	 * 
+	 * <p>Since the plugin is shutting down, flush the cache synchronously in this
+	 * thread.  Do not submit, or the database may be shutdown before all dirty
+	 * cache items can be saved.
+	 * </p>
+	 */
+	public static void onDisable() {
+		getInstance().onDisableInternal();
+	}
+	
+	/**
+	 * <p>This shuts down the cache and unloads all the players while 
+	 * updating the database if they have uncommitted values.  This also
+	 * will cancel any outstanding tasks and then flush the uncommitted
+	 * values if they still exist.
+	 * </p>
+	 * 
+	 * <p>This function runs all database transactions synchronously so as to 
+	 * ensure all data is writted to the database before the server is 
+	 * terminated.
+	 * </p>
+	 * 
+	 */
+	private void onDisableInternal() {
+		
+		// Disable the cache so future hits go straight to the database:
+		setEnabled( false );
+		
+		// save all dirty cache items and purge cache:
+		if ( getPlayers().size() > 0 ) {
+
+			// Create a new set so as to prevent keys from being removed when purging
+			// the getPlayers() collection:
+			Set<UUID> keys = new TreeSet<>(getPlayers().keySet());
+
+			for ( UUID key : keys ) {
+				// Remove the player from the cache and get the playerData:
+				TokenCachePlayerData playerData = getPlayers().remove( key );
+				
+				if ( playerData != null ) {
+					
+					// If the player has uncommitted value, then flush it to the database:
+					if ( playerData.getValueUncommitted() > 0 ) {
+						
+						int tokens = playerData.databaseStageTokens();
+						getCacheDatabase().addTokens( playerData.getPlayer(), tokens );
+						playerData.databaseFinalizeTokens();
+					}
+				}
+			}
+			
+		}
+		
+		// Cancel and flush any uncompleted tasks that are scheduled to run:
+		if ( getTasks().size() > 0  ) {
+			List<BukkitTask> keys = new ArrayList<>( getTasks().keySet() );
+			
+			for ( BukkitTask key : keys ) {
+				
+				if ( !key.isCancelled() ) {
+					// Cancel the task:
+					key.cancel();
+					
+					// Remove the task and get the player data:
+					TokenCachePlayerData playerData = getTasks().remove( key );
+					
+					if ( playerData != null ) {
+						
+						// If the player has uncommitted value, then flush it to the database:
+						if ( playerData.getValueUncommitted() > 0 ) {
+							
+							int tokens = playerData.databaseStageTokens();
+							getCacheDatabase().addTokens( playerData.getPlayer(), tokens );
+							playerData.databaseFinalizeTokens();
+						}
+					}
+					
+				}
+			}
+			
+		}
+	}
+
+	
+	private long getCacheWriteDelay() {
+		return getPlugin().getConfig().getLong( TOKEN_CACHE_WRITE_DELAY );
+	}
+	
+	private TokenCachePlayerData getPlayer( Player player ) {
+		
+		if ( !getPlayers().containsKey( player.getUniqueId() ) ) {
+			getPlayers().put( player.getUniqueId(), new TokenCachePlayerData( player ) );
+		}
+		
+		return getPlayers().get( player.getUniqueId() );
+	}
+	
+	private void removePlayerFromCache( TokenCachePlayerData playerData ) {
+		
+		if ( getPlayers().containsKey( playerData.getPlayer().getUniqueId() ) ) {
+			
+			getPlayers().remove( playerData.getPlayer().getUniqueId() );
+		}
+	}
+	
+	protected void submitAsyncDatabaseUpdate( TokenCachePlayerData playerData ) {
+		if ( !playerData.isAsyncDatabaseUpdateSubmitted() ) {
+			// Submit the async job
+			
+			if ( playerData.getValueUncommitted() > 0 ) {
+				
+				TokenCacheUpdateDatabaseTask task = new TokenCacheUpdateDatabaseTask( playerData );
+				BukkitTask bTask = getPlugin().getServer().getScheduler().runTaskLaterAsynchronously( 
+						getPlugin(), task, (getCacheWriteDelay() / 50) );
+				
+				// Store the BukkitTask in the playerData for possible future reference.
+				playerData.setBuckkitTask( bTask );
+				
+				getTasks().put( bTask, playerData );
+			}
+		}
+	}
+	
+	
+	protected void submitAsyncLoadPlayer( Player player ) {
+		
+		TokenCachePlayerData playerData = new TokenCachePlayerData( player );
+		
+		TokenCacheLoadPlayerTask task = new TokenCacheLoadPlayerTask( playerData );
+
+		// Submit task to run right away:
+		BukkitTask bTask = getPlugin().getServer().getScheduler().runTaskLaterAsynchronously( 
+						getPlugin(), task, 0 );
+		
+		// Store the BukkitTask in the playerData for possible future reference.
+		playerData.setBuckkitTask( bTask );
+		
+		getTasks().put( bTask, playerData );
+	}
+	
+	protected void submitAsyncUnloadPlayer( Player player ) {
+		
+		TokenCachePlayerData playerData = getPlayer( player );
+		
+		if ( playerData != null ) {
+			
+			// Remove from the player cache:
+			removePlayerFromCache( playerData );
+			
+			// Save to the database right away with no delay:
+			TokenCacheUpdateDatabaseTask task = new TokenCacheUpdateDatabaseTask( playerData );
+			BukkitTask bTask = getPlugin().getServer().getScheduler().runTaskLaterAsynchronously( 
+					getPlugin(), task, 0 );
+			
+			// Store the BukkitTask in the playerData for possible future reference.
+			playerData.setBuckkitTask( bTask );
+			
+		}
+		
+	}
+	
+	public int addTokens( Player player, int tokens ) {
+		int results = 0;
+		
+		if ( isEnabled() ) {
+			TokenCachePlayerData playerData = getPlayer( player );
+			results = playerData.addTokens( tokens );
+			submitAsyncDatabaseUpdate( playerData );
+		}
+		else {
+			// The cache is not enabled, so pass through directly to the database:
+			getCacheDatabase().addTokens( player, tokens );
+		}
+		
+		return results;
+	}
+	
+	public int getTokens( Player player ) {
+		int tokens = 0;
+		
+		if ( isEnabled() ) {
+			TokenCachePlayerData playerData = getPlayer( player );
+			tokens = playerData.getTokens();
+		}
+		else {
+			// The cache is not enabled, so pass through directly to the database:
+			getCacheDatabase().getTokens( player );
+		}
+		
+		return tokens;
+	}
+	
+	public void setTokens( Player player, int tokens ) {
+		if ( isEnabled() ) {
+			TokenCachePlayerData playerData = getPlayer( player );
+			playerData.setTokens( tokens );
+		}
+		else {
+			// The cache is not enabled, so pass through directly to the database:
+			getCacheDatabase().setTokens( player, tokens );
+		}
+	}
+
+	public int removeTokens( Player player, int tokens ) {
+		return addTokens( player, -1 * tokens );
+	}
+	
+	
+	public boolean hasTokens( Player player, int tokens ) {
+		boolean results = false;
+		
+		if ( isEnabled() ) {
+			TokenCachePlayerData playerData = getPlayer( player );
+			results = playerData.hasTokens( tokens );
+		}
+		else {
+			// The cache is not enabled, so pass through directly to the database:
+			results = getTokens( player ) >= tokens;
+		}
+		
+		return results;
+	}
+
+	
+	
+	
+	protected Tokens getPlugin() {
+		return plugin;
+	}
+	private void setPlugin( Tokens plugin ) {
+		this.plugin = plugin;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+	private void setEnabled( boolean enabled ) {
+		this.enabled = enabled;
+	}
+
+	public long getWriteDelay() {
+		return writeDelay;
+	}
+	public void setWriteDelay( long writeDelay ) {
+		this.writeDelay = writeDelay;
+	}
+
+	private Map<UUID, TokenCachePlayerData> getPlayers() {
+		return players;
+	}
+
+	protected TokenCacheDatabase getCacheDatabase() {
+		return cacheDatabase;
+	}
+
+	public Map<BukkitTask, TokenCachePlayerData> getTasks() {
+		return tasks;
+	}
+
+}

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCache.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCache.java
@@ -335,6 +335,7 @@ public class TokenCache {
 		if ( isEnabled() ) {
 			TokenCachePlayerData playerData = getPlayer( player );
 			playerData.setTokens( tokens );
+			submitAsyncDatabaseUpdate( playerData );
 		}
 		else {
 			// The cache is not enabled, so pass through directly to the database:

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCacheDatabase.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCacheDatabase.java
@@ -1,0 +1,69 @@
+package net.thirdshift.tokens.cache;
+
+import org.bukkit.entity.Player;
+
+import net.thirdshift.tokens.Tokens;
+
+public class TokenCacheDatabase {
+
+	private TokenCache tokenCache;
+	
+	protected TokenCacheDatabase( TokenCache tokenCache ) {
+		super();
+		
+		this.tokenCache = tokenCache;
+	}
+	
+    private TokenCache getTokenCache() {
+		return tokenCache;
+	}
+
+    private Tokens getPlugin() {
+    	return getTokenCache().getPlugin();
+    }
+    
+	/**
+     * Check a player's balance of tokens.
+     * @param player Target player
+     * @return Current balance of Player's tokens
+     */
+    public int getTokens(Player player){
+        if( getPlugin().getTokensConfigHandler().isRunningMySQL() ) {
+            return getPlugin().getMySQL().getTokens(player);
+        }
+        else {
+            return getPlugin().getSqllite().getTokens(player);
+        }
+    }
+
+    /**
+     * Adds Tokens to a current player's balance
+     * @param player Target player
+     * @param tokensIn Amount of tokens
+     */
+    public void addTokens(Player player, int tokensIn){
+        if( getPlugin().getTokensConfigHandler().isRunningMySQL() ) {
+        	getPlugin().getMySQL().addTokens(player, tokensIn);
+        } 
+        else {
+        	getPlugin().getSqllite().addTokens(player, tokensIn );
+        }
+    }
+    
+    
+    /**
+     * Sets a current player's balance to a specific amount of tokens.
+     * 
+     * @param player Target player
+     * @param tokensIn Amount of tokens
+     */
+    public void setTokens(Player player, int tokensIn){
+    	if( getPlugin().getTokensConfigHandler().isRunningMySQL() ) {
+    		getPlugin().getMySQL().setTokens(player, tokensIn);
+    	} 
+    	else {
+    		getPlugin().getSqllite().setTokens(player, tokensIn );
+    	}
+    }
+    
+}

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCacheDatabase.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCacheDatabase.java
@@ -65,5 +65,16 @@ public class TokenCacheDatabase {
     		getPlugin().getSqllite().setTokens(player, tokensIn );
     	}
     }
+
+	public void closeConnections()
+	{
+    	if( getPlugin().getTokensConfigHandler().isRunningMySQL() ) {
+    		getPlugin().getMySQL().closeConnection();
+    	} 
+    	else {
+    		getPlugin().getSqllite().closeConnection();
+    	}
+		
+	}
     
 }

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCacheDatabase.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCacheDatabase.java
@@ -27,7 +27,7 @@ public class TokenCacheDatabase {
      * @param player Target player
      * @return Current balance of Player's tokens
      */
-    public int getTokens(Player player){
+    public int getTokens(Player player) {
         if( getPlugin().getTokensConfigHandler().isRunningMySQL() ) {
             return getPlugin().getMySQL().getTokens(player);
         }
@@ -41,7 +41,7 @@ public class TokenCacheDatabase {
      * @param player Target player
      * @param tokensIn Amount of tokens
      */
-    public void addTokens(Player player, int tokensIn){
+    public void addTokens(Player player, int tokensIn) {
         if( getPlugin().getTokensConfigHandler().isRunningMySQL() ) {
         	getPlugin().getMySQL().addTokens(player, tokensIn);
         } 

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCacheEvents.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCacheEvents.java
@@ -1,0 +1,26 @@
+package net.thirdshift.tokens.cache;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class TokenCacheEvents
+		implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerJoin(PlayerJoinEvent event) {
+    	
+    	Player player = event.getPlayer();
+    	TokenCache.getInstance().submitAsyncLoadPlayer( player );
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+    	
+     	Player player = event.getPlayer();
+    	TokenCache.getInstance().submitAsyncUnloadPlayer( player );
+    }
+}

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCacheLoadPlayerTask.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCacheLoadPlayerTask.java
@@ -15,11 +15,14 @@ implements Runnable
 	
 		TokenCache tCache = TokenCache.getInstance();
 		
+		tCache.journal( playerData, "TokenCacheLoadPlayerTask.run(): before loading from DB.");
 		
 		int tokens = tCache.getCacheDatabase().getTokens( playerData.getPlayer() );
 		
 		String stats = playerData.setInitialValue( tokens );
 		tCache.getPlugin().getLogger().info( stats );
+
+		tCache.journal( playerData, "TokenCacheLoadPlayerTask.run(): finished loading from DB.");
 		
 		// If valueUncommitted is non-zero, then that means more
 		// transactions have been added and needs to schedule 

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCacheLoadPlayerTask.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCacheLoadPlayerTask.java
@@ -1,0 +1,34 @@
+package net.thirdshift.tokens.cache;
+
+public class TokenCacheLoadPlayerTask
+implements Runnable
+{
+	private TokenCachePlayerData playerData;
+
+	public TokenCacheLoadPlayerTask( TokenCachePlayerData playerData ) {
+		super();
+	
+		this.playerData = playerData;
+	}
+
+	public void run() {
+	
+		TokenCache tCache = TokenCache.getInstance();
+		
+		
+		int tokens = tCache.getCacheDatabase().getTokens( playerData.getPlayer() );
+		
+		playerData.setInitialValue( tokens );
+		
+		
+		// If valueUncommitted is non-zero, then that means more
+		// transactions have been added and needs to schedule 
+		// another database update.  If the job is submitted when 
+		// more data is added, it will not submit a new job.
+		tCache.submitAsyncDatabaseUpdate( playerData );
+		
+		// Remove the saved task:
+		tCache.getTasks().remove( playerData.getBukkitTask() );
+	}
+
+}

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCacheLoadPlayerTask.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCacheLoadPlayerTask.java
@@ -18,8 +18,8 @@ implements Runnable
 		
 		int tokens = tCache.getCacheDatabase().getTokens( playerData.getPlayer() );
 		
-		playerData.setInitialValue( tokens );
-		
+		String stats = playerData.setInitialValue( tokens );
+		tCache.getPlugin().getLogger().info( stats );
 		
 		// If valueUncommitted is non-zero, then that means more
 		// transactions have been added and needs to schedule 

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayerData.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayerData.java
@@ -212,13 +212,18 @@ public class TokenCachePlayerData {
 	 * </p>
 	 * 
 	 * @param tokens
+	 * @return boolean indicating if the player was synchronized with the database
 	 */
-	protected void synchronizeFromDatabase( int tokensDB ) {
+	protected boolean synchronizeFromDatabase( int tokensDB ) {
+		boolean synched = false;
+		
 		synchronized ( lock ) {
 			if ( tokensDB != (valueDB + valueTransition ) ) {
 				valueDB = tokensDB - valueTransition;
+				synched = true;
 			}
 		}
+		return synched;
 	}
 	
 	

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayerData.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayerData.java
@@ -195,6 +195,11 @@ public class TokenCachePlayerData {
 	
 	protected void setInitialValue( int tokens ) {
 		synchronized ( lock ) {
+			
+			System.err.println("### @@@ TokenCachePlayer: setInitialValue: player: " + 
+						getPlayer().getName() + "  valueDB= " + valueDB +
+						"  new value= "  + tokens );
+			
 			valueDB = tokens;
 		}
 	}

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayerData.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayerData.java
@@ -224,7 +224,7 @@ public class TokenCachePlayerData {
 	 * the value in the database.
 	 * </p>
 	 * 
-	 * @param tokens
+	 * @param tokensDB
 	 * @return boolean indicating if the player was synchronized with the database
 	 */
 	protected boolean synchronizeFromDatabase( int tokensDB ) {

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayerData.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayerData.java
@@ -80,6 +80,19 @@ public class TokenCachePlayerData {
 		this.player = player;
 	}
 
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		
+		sb.append( getPlayer().getName() ).append( " [tokens= " ).append( getTokens() )
+				.append( " (uncommitted= " ).append( getValueUncommitted() )
+				.append( isAsyncDatabaseUpdateSubmitted() ? " *UpdateSubmitted*" : "" )
+				.append( " db= " ).append( valueDB )
+				.append( " transition= " ).append( valueTransition )
+				.append( " )]  " );
+		
+		return sb.toString();
+	}
 	
 	/**
 	 * <p>This function adds the number of tokens to the player.
@@ -173,6 +186,7 @@ public class TokenCachePlayerData {
 			valueUncommitted = 0;
 			
 			tokens = valueTransition;
+			
 		}
 		return tokens;
 	}
@@ -183,6 +197,8 @@ public class TokenCachePlayerData {
 		synchronized ( lock ) {
 			valueDB += valueTransition;
 			valueTransition = 0;
+			
+			setAsyncDatabaseUpdateSubmitted( false );
 		}
 	}
 
@@ -193,15 +209,12 @@ public class TokenCachePlayerData {
 	}
 	
 	
-	protected void setInitialValue( int tokens ) {
+	protected String setInitialValue( int tokens ) {
 		synchronized ( lock ) {
-			
-			System.err.println("### @@@ TokenCachePlayer: setInitialValue: player: " + 
-						getPlayer().getName() + "  valueDB= " + valueDB +
-						"  new value= "  + tokens );
 			
 			valueDB = tokens;
 		}
+		return "### TokenCachePlayer: setInitialValue: " + toString();
 	}
 	
 
@@ -253,11 +266,14 @@ public class TokenCachePlayerData {
 //		this.valueUncommitted = valueUncommitted;
 //	}
 
+
 	protected boolean isAsyncDatabaseUpdateSubmitted() {
 		return asyncDatabaseUpdateSubmitted;
 	}
 	protected void setAsyncDatabaseUpdateSubmitted( boolean asyncDatabaseUpdateSubmitted ) {
-		this.asyncDatabaseUpdateSubmitted = asyncDatabaseUpdateSubmitted;
+		synchronized ( lock ) {
+			this.asyncDatabaseUpdateSubmitted = asyncDatabaseUpdateSubmitted;
+		}
 	}
 
 	public BukkitTask getBukkitTask() {

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayerData.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayerData.java
@@ -120,9 +120,9 @@ public class TokenCachePlayerData {
 	 * adjustment amount that needs to be stored within the valueUncommited
 	 * field.  As simple as this is, we really need to take in to consideration
 	 * database updates that may be in progress.  So that modifies the 
-	 * calculations that we must perform, which is:
+	 * calculations that we must perform:
 	 * </p>
-	 * <pre>valueUncommited = (valueDB + valueTransition)</pre>
+	 * <pre>valueUncommited = tokens - (valueDB + valueTransition)</pre>
 	 * <p>The reason we need to include valueTransition is because if a
 	 * database update is in progress, then valueTransition will represent
 	 * how the players record will be reflected once the transaction is 
@@ -134,7 +134,7 @@ public class TokenCachePlayerData {
 	public void setTokens( int tokens ) {
 			
 		synchronized ( lock ) {
-			valueUncommitted = (valueDB + valueTransition);
+			valueUncommitted = tokens - (valueDB + valueTransition);
 		}
 	}
 

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayerData.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayerData.java
@@ -204,6 +204,24 @@ public class TokenCachePlayerData {
 		}
 	}
 	
+
+	/**
+	 * <p>This function will check to see if the token value in the cache
+	 * for the database (both valueDB + valueTransition) is the same as 
+	 * the value in the database.
+	 * </p>
+	 * 
+	 * @param tokens
+	 */
+	protected void synchronizeFromDatabase( int tokensDB ) {
+		synchronized ( lock ) {
+			if ( tokensDB != (valueDB + valueTransition ) ) {
+				valueDB = tokensDB - valueTransition;
+			}
+		}
+	}
+	
+	
 	protected Player getPlayer() {
 		return player;
 	}
@@ -243,6 +261,5 @@ public class TokenCachePlayerData {
 	public void setBuckkitTask( BukkitTask bukkitTask ) {
 		this.bukkitTask = bukkitTask;
 	}
-	
 	
 }

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayerData.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayerData.java
@@ -1,0 +1,243 @@
+package net.thirdshift.tokens.cache;
+
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * <p>This class represents the temporal state of a player's balance
+ * represented by both the internal (within the database) all the way 
+ * through to the uncommitted value.  There are three primary values
+ * and they server an important part to maintaining a fast and 
+ * reliable cache.
+ * </p>
+ * 
+ * <p>The cached values represent a gated cycle that are designed to 
+ * allow for minimal locking, with the fastest response.
+ * The following explains the purpose of the different values and
+ * hopefully their importance. 
+ * </p>
+ * 
+ * <ul>
+ *   <li><b>valueDB</b>: This always represents the value that is 
+ *   					 stored in the database.</li>
+ *   
+ *   <li><b>valueUncommittd</b>: This is value that has yet to be
+ *						committed to the database. This value can be
+ *						either positive or negative, and when combined
+ *						with <b>valueDb</b> and <b>valueTransition</b>
+ *						will represent the true balance of the player.
+ *						The true balance can never go negative.
+ *						</li>
+ *
+ *   <li><b>valueTransition</b>: To minimize locking, this value is the
+ *   					transitional value between the uncommitted amount
+ *   					and the database amount.  When writing to the 
+ *   					database, it first locks the uncommitted, setting it
+ *   					zero, and moving the value to the transition and then
+ *   					releases the lock. This value remains active until
+ *   					the database can be finalized on it's update, then
+ *   					it is added to the valueDB and then set to zero.
+ *   					</li>
+ * 
+ * </ul>
+ * 
+ * @author RoyalBlueRanger
+ *
+ */
+public class TokenCachePlayerData {
+
+	private Player player;
+	
+	// Value in database:
+	private int valueDB = 0;
+	
+	// Value in transition: 
+	private int valueTransition = 0;
+	
+	// Value uncommitted:
+	private int valueUncommitted = 0;
+	
+	/**
+	 *  This Object lock is used to synchronized the public side of this class
+	 *  and the protected side of this class which is the database transaction
+	 *  side of things.
+	 */
+	private Object lock = new Object();
+	
+	private boolean asyncDatabaseUpdateSubmitted = false;
+	
+	
+	/**
+	 * This is just to hold on to the BukkitTask when the database update is submitted.
+	 */
+	private BukkitTask bukkitTask;
+	
+	
+	
+	public TokenCachePlayerData( Player player ) {
+		super();
+		
+		this.player = player;
+	}
+
+	
+	/**
+	 * <p>This function adds the number of tokens to the player.
+	 * It uses a lock when adding to the valueUncommitted.
+	 * </p>
+	 * 
+	 * @param tokens
+	 */
+	public int addTokens( int tokens ) {
+		
+		synchronized ( lock ) {
+			valueUncommitted += tokens;
+		}
+		
+		return valueUncommitted;
+	}
+	
+	public int getTokens() {
+		int tokens = 0;
+		
+		synchronized ( lock ) {
+			tokens = valueDB + valueTransition + valueUncommitted;
+		}
+		
+		return tokens;
+	}
+	
+	/**
+	 * <p>This function effectively sets the player's balance to the given 
+	 * amount.  This is done by taking the total amount that's in the 
+	 * database (what's in valueDB) and makes adjustments to that value so
+	 * the resulting amount is equal to target token amount.  The valueDB
+	 * cannot be changed.
+	 * </p>
+	 * 
+	 * <p>The formula to perform this transaction is you take the target
+	 * tokens amount and subtract the valueDB amount, then that is the 
+	 * adjustment amount that needs to be stored within the valueUncommited
+	 * field.  As simple as this is, we really need to take in to consideration
+	 * database updates that may be in progress.  So that modifies the 
+	 * calculations that we must perform, which is:
+	 * </p>
+	 * <pre>valueUncommited = (valueDB + valueTransition)</pre>
+	 * <p>The reason we need to include valueTransition is because if a
+	 * database update is in progress, then valueTransition will represent
+	 * how the players record will be reflected once the transaction is 
+	 * complete.
+	 * </p>
+	 * 
+	 * @param tokens
+	 */
+	public void setTokens( int tokens ) {
+			
+		synchronized ( lock ) {
+			valueUncommitted = (valueDB + valueTransition);
+		}
+	}
+
+	/**
+	 * <p>This function removes the number of tokens to the player.
+	 * It negates the value of tokens and then calls addTokens.
+	 * </p>
+	 * 
+	 * @param tokens
+	 */
+	public int removeTokens( int tokens ) {
+		return addTokens( -1 * tokens );
+	}
+	
+	
+	/**
+	 * <p>The player's total token 
+	 * @param tokens
+	 * @return
+	 */
+	public boolean hasTokens( int tokens ) {
+		boolean results = false;
+		
+		synchronized ( lock ) {
+			results = ( tokens > getTokens());
+		}
+		
+		return results;
+	}
+
+	
+	protected int databaseStageTokens() {
+		int tokens = 0;
+		synchronized ( lock ) {
+			valueTransition += valueUncommitted;
+			valueUncommitted = 0;
+			
+			tokens = valueTransition;
+		}
+		return tokens;
+	}
+	
+	
+	protected void databaseFinalizeTokens() {
+		
+		synchronized ( lock ) {
+			valueDB += valueTransition;
+			valueTransition = 0;
+		}
+	}
+
+	protected int getValueUncommitted() {
+		synchronized ( lock ) {
+			return valueUncommitted;
+		}
+	}
+	
+	
+	protected void setInitialValue( int tokens ) {
+		synchronized ( lock ) {
+			valueDB = tokens;
+		}
+	}
+	
+	protected Player getPlayer() {
+		return player;
+	}
+	protected void setPlayer( Player player ) {
+		this.player = player;
+	}
+	
+	
+//	private int getValueDB() {
+//		return valueDB;
+//	}
+//	private void setValueDB( int valueDB ) {
+//		this.valueDB = valueDB;
+//	}
+//
+//	private int getValueTransition() {
+//		return valueTransition;
+//	}
+//	private void setValueTransition( int valueTransition ) {
+//		this.valueTransition = valueTransition;
+//	}
+
+//	private void setValueUncommitted( int valueUncommitted ) {
+//		this.valueUncommitted = valueUncommitted;
+//	}
+
+	protected boolean isAsyncDatabaseUpdateSubmitted() {
+		return asyncDatabaseUpdateSubmitted;
+	}
+	protected void setAsyncDatabaseUpdateSubmitted( boolean asyncDatabaseUpdateSubmitted ) {
+		this.asyncDatabaseUpdateSubmitted = asyncDatabaseUpdateSubmitted;
+	}
+
+	public BukkitTask getBukkitTask() {
+		return bukkitTask;
+	}
+	public void setBuckkitTask( BukkitTask bukkitTask ) {
+		this.bukkitTask = bukkitTask;
+	}
+	
+	
+}

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayersTokensData.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCachePlayersTokensData.java
@@ -1,0 +1,28 @@
+package net.thirdshift.tokens.cache;
+
+public class TokenCachePlayersTokensData {
+
+	private String uuid;
+	private int tokens;
+	
+	public TokenCachePlayersTokensData( String uuid, int tokens ) {
+		super();
+		
+		this.uuid = uuid;
+		this.tokens = tokens;
+	}
+
+	public String getUuid() {
+		return uuid;
+	}
+	public void setUuid( String uuid ) {
+		this.uuid = uuid;
+	}
+
+	public int getTokens() {
+		return tokens;
+	}
+	public void setTokens( int tokens ) {
+		this.tokens = tokens;
+	}
+}

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCacheStats.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCacheStats.java
@@ -1,0 +1,261 @@
+package net.thirdshift.tokens.cache;
+
+public class TokenCacheStats {
+
+	private long startMs;
+	
+	private boolean enabled = false;
+	
+	private int loadPlayer = 0;
+	private int unloadPlayer = 0;
+	private int removePlayer = 0;
+	private int getPlayer = 0;
+
+	private int submitDatabaseUpdate = 0;
+	private int synchronizePlayers = 0;
+	
+	private int addTokens = 0;
+	private int getTokens = 0;
+	private int setTokens = 0;
+	private int removeTokens = 0;
+	private int hasTokens = 0;
+	
+	private Object lock1 = new Object();
+	private Object lock2 = new Object();
+	private Object lock3 = new Object();
+	private Object lock4 = new Object();
+	private Object lock5 = new Object();
+	private Object lock6 = new Object();
+	private Object lock7 = new Object();
+	private Object lock8 = new Object();
+	private Object lock9 = new Object();
+	private Object lockA = new Object();
+	private Object lockB = new Object();
+	
+	public TokenCacheStats() {
+		super();
+		
+		this.startMs = System.currentTimeMillis();
+	}
+	
+	/**
+	 * <p>If enabled, stats will be collected.
+	 * </p>
+	 * 
+	 * @return
+	 */
+	public boolean isEnabled() {
+		return enabled;
+	}
+	public void setEnabled( boolean enabled ) {
+		this.enabled = enabled;
+	}
+
+	
+	public String displayStats() {
+		StringBuilder sb = new StringBuilder();
+		
+		sb.append( "TokenCache stats: loadPlayer=" ).append( getLoadPlayer() )
+			.append( " unloadPlayer=" ).append( getUnloadPlayer() )
+			.append( " removePlayer=" ).append( getRemovePlayer() )
+			.append( " getPlayer=" ).append( getGetPlayer() )
+			
+			.append( " submitDatabaseUpdate=" ).append( getSubmitDatabaseUpdate() )
+			.append( " synchronizeDatabase=" ).append( getSynchronizePlayers() )
+			
+			.append( " addTokens=" ).append( getAddTokens() )
+			.append( " getTokens=" ).append( getGetTokens() )
+			.append( " setTokens=" ).append( getSetTokens() )
+			.append( " removeTokens=" ).append( getRemoveTokens() )
+			.append( " hasTokens=" ).append( getHasTokens() );
+		
+		return sb.toString();
+	}
+	
+	public void clear() {
+		
+		setStartMs( System.currentTimeMillis() );
+
+		setLoadPlayer( 0 );
+		setUnloadPlayer( 0 );
+		setRemovePlayer( 0 );
+		setGetPlayer( 0 );
+		
+		setSubmitDatabaseUpdate( 0 );
+		setSynchronizePlayers( 0 );
+		
+		setAddTokens( 0 );
+		setGetTokens( 0 );
+		setSetTokens( 0 );
+		setRemoveTokens( 0 );
+		setHasTokens( 0 );
+		
+	}
+	
+	public void incrementGetPlayers() {
+		if ( enabled ) {
+			synchronized ( lock1 ) {
+				getPlayer++;
+			}
+		}
+	}
+	public void incrementRemovePlayers() {
+		if ( enabled ) {
+			synchronized ( lock2 ) {
+				removePlayer++;
+			}
+		}
+	}
+	public void incrementLoadPlayers() {
+		if ( enabled ) {
+			synchronized ( lock3 ) {
+				loadPlayer++;
+			}
+		}
+	}
+	public void incrementUnloadPlayers() {
+		if ( enabled ) {
+			synchronized ( lock4 ) {
+				unloadPlayer++;
+			}
+		}
+	}
+	
+	
+	public void incrementSubmitDatabaseUpdate() {
+		if ( enabled ) {
+			synchronized ( lock5 ) {
+				submitDatabaseUpdate++;
+			}
+		}
+	}
+	public void incrementSubmitSynchronizePlayers() {
+		if ( enabled ) {
+			synchronized ( lockB ) {
+				synchronizePlayers++;
+			}
+		}
+	}
+	
+	
+	public void incrementAddTokens() {
+		if ( enabled ) {
+			synchronized ( lock6 ) {
+				addTokens++;
+			}
+		}
+	}
+	public void incrementGetTokens() {
+		if ( enabled ) {
+			synchronized ( lock7 ) {
+				getTokens++;
+			}
+		}
+	}
+	public void incrementSetTokens() {
+		if ( enabled ) {
+			synchronized ( lock8 ) {
+				setTokens++;
+			}
+		}
+	}
+	public void incrementRemveTokens() {
+		if ( enabled ) {
+			synchronized ( lock9 ) {
+				removeTokens++;
+			}
+		}
+	}
+	public void incrementHasTokens() {
+		if ( enabled ) {
+			synchronized ( lockA ) {
+				hasTokens++;
+			}
+		}
+	}
+	
+	public long getStartMs() {
+		return startMs;
+	}
+	public void setStartMs( long startMs ) {
+		this.startMs = startMs;
+	}
+	
+	public int getGetPlayer() {
+		return getPlayer;
+	}
+	public void setGetPlayer( int getPlayer ) {
+		this.getPlayer = getPlayer;
+	}
+	
+	public int getRemovePlayer() {
+		return removePlayer;
+	}
+	public void setRemovePlayer( int removePlayer ) {
+		this.removePlayer = removePlayer;
+	}
+	
+	public int getLoadPlayer() {
+		return loadPlayer;
+	}
+	public void setLoadPlayer( int loadPlayer ) {
+		this.loadPlayer = loadPlayer;
+	}
+	
+	public int getUnloadPlayer() {
+		return unloadPlayer;
+	}
+	public void setUnloadPlayer( int unloadPlayer ) {
+		this.unloadPlayer = unloadPlayer;
+	}
+	
+	public int getSubmitDatabaseUpdate() {
+		return submitDatabaseUpdate;
+	}
+	public void setSubmitDatabaseUpdate( int submitDatabaseUpdate ) {
+		this.submitDatabaseUpdate = submitDatabaseUpdate;
+	}
+	
+	public int getSynchronizePlayers() {
+		return synchronizePlayers;
+	}
+	public void setSynchronizePlayers( int synchronizePlayers ) {
+		this.synchronizePlayers = synchronizePlayers;
+	}
+
+	public int getAddTokens() {
+		return addTokens;
+	}
+	public void setAddTokens( int addTokens ) {
+		this.addTokens = addTokens;
+	}
+	
+	public int getGetTokens() {
+		return getTokens;
+	}
+	public void setGetTokens( int getTokens ) {
+		this.getTokens = getTokens;
+	}
+	
+	public int getSetTokens() {
+		return setTokens;
+	}
+	public void setSetTokens( int setTokens ) {
+		this.setTokens = setTokens;
+	}
+	
+	public int getRemoveTokens() {
+		return removeTokens;
+	}
+	public void setRemoveTokens( int removeTokens ) {
+		this.removeTokens = removeTokens;
+	}
+	
+	public int getHasTokens() {
+		return hasTokens;
+	}
+	public void setHasTokens( int hasTokens ) {
+		this.hasTokens = hasTokens;
+	}
+	
+}

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCacheStats.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCacheStats.java
@@ -50,8 +50,12 @@ public class TokenCacheStats {
 	public void setEnabled( boolean enabled ) {
 		this.enabled = enabled;
 	}
+	public void toggleEnabled() {
+		this.enabled = !this.enabled;
+	}
 
-	
+
+
 	public String displayStats() {
 		StringBuilder sb = new StringBuilder();
 		

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCacheSynchronizeCacheTask.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCacheSynchronizeCacheTask.java
@@ -1,0 +1,99 @@
+package net.thirdshift.tokens.cache;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.entity.Player;
+
+/**
+ * <p>This task performs a few different housekeeping operations
+ * that are focused on updating the status of the players that are 
+ * in the cache.
+ * </p>
+ * 
+ * <p>The first major function this performs, is to check to see if
+ * the player is still online. The cache should only contain online
+ * players, and so this will purge offline players. It should be
+ * noted that there should never be a situation where a player 
+ * would be found in this state, since they should be unloaded at
+ * the time when they leave the game. But just in case this will 
+ * provide a cache clean up.
+ * </p>
+ * 
+ * <p>Another important function this performs is it "tries" to 
+ * update the Player instance for the player.  If a player leaves
+ * the game and they are not unloaded, then their new Player 
+ * object will not be in the cache.  Therefore if the Player
+ * object stored in the cache is not the exact same object that
+ * is returned by the server, then this will update the cache with
+ * the most current Player object for that player.
+ * </p>
+ * 
+ * <p>Then, finally, the task that is the primary purpose of this whole
+ * process, is to check all active players to ensure the cache's 
+ * database amount matches what is actually within the database.  If
+ * they don't match, then update the cache to reflect the database's value.
+ * This is check is performed in such a way that if a player is undergoing
+ * a database update, then it will be able to take in to consideration the 
+ * projected final database value and this will still be able to make the
+ * correct adjustments.
+ * </p>
+ *
+ */
+public class TokenCacheSynchronizeCacheTask
+				implements Runnable
+{
+	
+	public TokenCacheSynchronizeCacheTask() {
+		super();
+		
+	}
+	
+	public void run() {
+
+		TokenCache tCache = TokenCache.getInstance();
+		
+		List<String> keys = new ArrayList<>( tCache.getPlayerStrings().keySet() );
+		
+		for ( String key : keys ) {
+			TokenCachePlayerData playerData = tCache.getPlayerStrings().get( key );
+			
+			// Check to make sure the player is still online, if not, remove them from the cache:
+			Player currentPlayer = tCache.getPlugin().getServer().getPlayer( playerData.getPlayer().getUniqueId() );
+			
+			if ( currentPlayer == null || !currentPlayer.isOnline() ) {
+				// Player is no longer online so unload them:
+				tCache.submitAsyncUnloadPlayer( playerData.getPlayer() );
+			}
+			else {
+				if ( currentPlayer.equals( playerData.getPlayer() )  ) {
+					// If a player logs off and then back on, will the Player object be the same?
+					// Not sure how you could tell, but I suspect they will be different objects.
+					playerData.setPlayer( currentPlayer );
+				}
+				
+				// check the synchronization:
+				int tokens = tCache.getCacheDatabase().getTokens( playerData.getPlayer() );
+				
+				playerData.synchronizeFromDatabase( tokens );
+			}
+				
+		}
+		
+//		List<TokenCachePlayersTokensData> players = 
+//								tCache.getCacheDatabase().getAllPlayerTokens();
+//		
+//		for ( TokenCachePlayersTokensData playerTokens : players ) {
+//			
+//			if ( tCache.getPlayerStrings().containsKey( playerTokens.getUuid() ) ) {
+//				
+//				TokenCachePlayerData playerData = tCache.getPlayerStrings().get( playerTokens.getUuid() );
+//				
+//				playerData.synchronizeFromDatabase( playerTokens.getTokens() );
+//			}
+//			
+//		}
+
+		
+	}
+}

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCacheSynchronizeCacheTask.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCacheSynchronizeCacheTask.java
@@ -54,9 +54,9 @@ public class TokenCacheSynchronizeCacheTask
 	
 	public void run() {
 
-		int cachedItems = 0;
+		int cachedPlayers = 0;
 		int cachedUnloaded = 0;
-		int playersUpdated = 0;
+//		int playersUpdated = 0;
 		int playersSyncd = 0;
 		
 		TokenCache tCache = TokenCache.getInstance();
@@ -75,12 +75,13 @@ public class TokenCacheSynchronizeCacheTask
 				cachedUnloaded++;
 			}
 			else {
-				if ( currentPlayer.equals( playerData.getPlayer() )  ) {
-					// If a player logs off and then back on, will the Player object be the same?
-					// Not sure how you could tell, but I suspect they will be different objects.
-					playerData.setPlayer( currentPlayer );
-					playersUpdated++;
-				}
+				// NOTE: currentPlayer.equals() does not work correctly... skip this for now:
+//				if ( currentPlayer.equals( playerData.getPlayer() )  ) {
+//					// If a player logs off and then back on, will the Player object be the same?
+//					// Not sure how you could tell, but I suspect they will be different objects.
+//					playerData.setPlayer( currentPlayer );
+//					playersUpdated++;
+//				}
 				
 				// check the synchronization:
 				int tokens = tCache.getCacheDatabase().getTokens( playerData.getPlayer() );
@@ -90,13 +91,13 @@ public class TokenCacheSynchronizeCacheTask
 				}
 			}
 				
-			cachedItems++;
+			cachedPlayers++;
 		}
 		
 		
 		String message = tCache.getPlugin().messageHandler.
         		formatMessage( "tokens.cache.sync.completed.message", 
-        				cachedItems, cachedUnloaded, playersUpdated, playersSyncd );
+        				cachedPlayers, cachedUnloaded, playersSyncd );
 		
 		if ( commandSender != null ) {
 			commandSender.sendMessage( message );

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCacheSynchronizeCacheTask.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCacheSynchronizeCacheTask.java
@@ -58,6 +58,7 @@ public class TokenCacheSynchronizeCacheTask
 		int cachedUnloaded = 0;
 //		int playersUpdated = 0;
 		int playersSyncd = 0;
+		int playersUpdated = 0;
 		
 		TokenCache tCache = TokenCache.getInstance();
 		
@@ -89,6 +90,15 @@ public class TokenCacheSynchronizeCacheTask
 				if ( playerData.synchronizeFromDatabase( tokens ) ) {
 					playersSyncd++;
 				}
+				
+				if ( !playerData.isAsyncDatabaseUpdateSubmitted() && playerData.getValueUncommitted() > 0 ) {
+					
+					// Use the task but don't submit it, just run the function directly since this is already 
+					// running in an async thread.
+					TokenCacheUpdateDatabaseTask task = new TokenCacheUpdateDatabaseTask( playerData );
+					task.run();
+					playersUpdated++;
+				}
 			}
 				
 			cachedPlayers++;
@@ -97,7 +107,7 @@ public class TokenCacheSynchronizeCacheTask
 		
 		String message = tCache.getPlugin().messageHandler.
         		formatMessage( "tokens.cache.sync.completed.message", 
-        				cachedPlayers, cachedUnloaded, playersSyncd );
+        				cachedPlayers, cachedUnloaded, playersSyncd, playersUpdated );
 		
 		if ( commandSender != null ) {
 			commandSender.sendMessage( message );

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCacheUpdateDatabaseTask.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCacheUpdateDatabaseTask.java
@@ -17,9 +17,13 @@ public class TokenCacheUpdateDatabaseTask
 		
 		int tokens = playerData.databaseStageTokens();
 		
+		tCache.journal( playerData, "TokenCacheUpdateDatabaseTask.run: Running. ");
+		
 		tCache.getCacheDatabase().addTokens( playerData.getPlayer(), tokens );
 		
 		playerData.databaseFinalizeTokens();
+
+		tCache.journal( playerData, "TokenCacheUpdateDatabaseTask.run: Finished. ");
 		
 		// If valueUncommitted is non-zero, then that means more
 		// transactions have been added and needs to schedule 
@@ -28,7 +32,9 @@ public class TokenCacheUpdateDatabaseTask
 		tCache.submitAsyncDatabaseUpdate( playerData );
 		
 		// Remove the saved task:
-		tCache.getTasks().remove( playerData.getBukkitTask() );
+		if ( playerData.getBukkitTask() != null ) {
+			tCache.getTasks().remove( playerData.getBukkitTask() );
+		}
 	}
 
 }

--- a/src/main/java/net/thirdshift/tokens/cache/TokenCacheUpdateDatabaseTask.java
+++ b/src/main/java/net/thirdshift/tokens/cache/TokenCacheUpdateDatabaseTask.java
@@ -1,0 +1,34 @@
+package net.thirdshift.tokens.cache;
+
+public class TokenCacheUpdateDatabaseTask
+		implements Runnable
+{
+	private TokenCachePlayerData playerData;
+	
+	public TokenCacheUpdateDatabaseTask( TokenCachePlayerData playerData ) {
+		super();
+		
+		this.playerData = playerData;
+	}
+	
+	public void run() {
+
+		TokenCache tCache = TokenCache.getInstance();
+		
+		int tokens = playerData.databaseStageTokens();
+		
+		tCache.getCacheDatabase().addTokens( playerData.getPlayer(), tokens );
+		
+		playerData.databaseFinalizeTokens();
+		
+		// If valueUncommitted is non-zero, then that means more
+		// transactions have been added and needs to schedule 
+		// another database update.  If the job is submitted when 
+		// more data is added, it will not submit a new job.
+		tCache.submitAsyncDatabaseUpdate( playerData );
+		
+		// Remove the saved task:
+		tCache.getTasks().remove( playerData.getBukkitTask() );
+	}
+
+}

--- a/src/main/java/net/thirdshift/tokens/commands/tokens/CommandTokens.java
+++ b/src/main/java/net/thirdshift/tokens/commands/tokens/CommandTokens.java
@@ -290,24 +290,44 @@ public class CommandTokens implements CommandExecutor {
         	
             return true;
         }
+        
         else if ( args[0].equalsIgnoreCase("cache") && 
         		(commandSender.hasPermission("tokens.cache") || commandSender.isOp()) ) {
-        	if ( args.length > 1 && args[1].equalsIgnoreCase("stats") ) {
-        		commandSender.sendMessage( "/tokens cache stats: coming soon... under construction." );
-        	}
-        	else if ( args.length > 1 && args[1].equalsIgnoreCase("sync") ) {
+        	
+        	if ( args.length > 1 && args[1].equalsIgnoreCase("sync") ) {
                 commandSender.sendMessage(plugin.messageHandler.formatMessage("tokens.cache.sync.start.message"));
                 TokenCache.getInstance().submitAsyncSynchronizePlayers( commandSender );
         	}
+        	else if ( args.length > 2 && args[1].equalsIgnoreCase("stats") && args[2].equalsIgnoreCase("toggle") ) {
+        		TokenCache.getInstance().getStats().setEnabled( !TokenCache.getInstance().getStats().isEnabled() );;
+        		commandSender.sendMessage( plugin.messageHandler.formatMessage("tokens.cache.stats.toggled",
+        				TokenCache.getInstance().getStats().isEnabled()) );
+        	}
+        	else if ( args.length > 2 && args[1].equalsIgnoreCase("stats") && args[2].equalsIgnoreCase("clear") ) {
+        		TokenCache.getInstance().getStats().clear();
+        		commandSender.sendMessage( plugin.messageHandler.formatMessage("tokens.cache.stats.cleared") );
+        	}
+        	else if ( args.length > 2 && args[1].equalsIgnoreCase("stats") && args[2].equalsIgnoreCase("dump") ) {
+        		String playerCacheDump = TokenCache.getInstance().getPlayerDumpStats();
+        		commandSender.sendMessage( playerCacheDump );
+        	}
+        	else if ( args.length > 1 && args[1].equalsIgnoreCase("stats") ) {
+        		commandSender.sendMessage( TokenCache.getInstance().getStats().displayStats() );
+        	}
         	else {
-                commandSender.sendMessage(ChatColor.GREEN + "===============[ " + ChatColor.GOLD + "Tokens Cache Help" + ChatColor.GREEN + " ]===============");
+                commandSender.sendMessage(ChatColor.GREEN + "===============[ " + ChatColor.GOLD + "Tokens Cache Help " +
+                			ChatColor.BLUE + plugin.getDescription().getVersion() + ChatColor.GREEN + " ]===============");
                 commandSender.sendMessage(ChatColor.AQUA + "/tokens cache help " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-help"));
                 commandSender.sendMessage(ChatColor.AQUA + "/tokens cache sync " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-sync"));
                 commandSender.sendMessage(ChatColor.AQUA + "/tokens cache stats " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-stats"));
+                commandSender.sendMessage(ChatColor.AQUA + "/tokens cache stats toggle " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-stats-toggle"));
+                commandSender.sendMessage(ChatColor.AQUA + "/tokens cache stats clear " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-stats-clear"));
+                commandSender.sendMessage(ChatColor.AQUA + "/tokens cache stats dump " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-stats-dump"));
 
         	}
         	return true;
         }
+        
         else if(args.length==1) {
             Player target = Bukkit.getPlayerExact(args[0]);
             if(commandSender instanceof Player) {
@@ -451,7 +471,8 @@ public class CommandTokens implements CommandExecutor {
     private void displayTokenHelp( CommandSender commandSender ) {
     	boolean isConsole = !(commandSender instanceof Player) || commandSender.isOp();
     	
-        commandSender.sendMessage(ChatColor.GREEN + "===============[ " + ChatColor.GOLD + "Tokens Help" + ChatColor.GREEN + " ]===============");
+        commandSender.sendMessage(ChatColor.GREEN + "===============[ " + ChatColor.GOLD + "Tokens Help " +
+    								ChatColor.BLUE + plugin.getDescription().getVersion() + ChatColor.GREEN + " ]===============");
         commandSender.sendMessage(ChatColor.AQUA + "/tokens help " + ChatColor.GRAY + " Displays this helpful text");
         commandSender.sendMessage(ChatColor.AQUA + "/tokens" + ChatColor.GRAY + " Displays your number of tokens");
         if (commandSender.hasPermission("tokens.add") || isConsole) {

--- a/src/main/java/net/thirdshift/tokens/commands/tokens/CommandTokens.java
+++ b/src/main/java/net/thirdshift/tokens/commands/tokens/CommandTokens.java
@@ -112,11 +112,11 @@ public class CommandTokens implements CommandExecutor {
                     objects.add("/tokens set <player name> <tokens amount>");
                     commandSender.sendMessage(plugin.messageHandler.useMessage("tokens.errors.invalid-command.message", objects));
                 }
-                if(!plugin.messageHandler.getMessage("tokens.errors.invalid-command-correction").isEmpty()){
+                if(!plugin.messageHandler.getMessage("tokens.errors.invalid-command.correction").isEmpty()){
                     List<Object> objects = new ArrayList<>();
                     objects.add(new PlayerSender((Player)commandSender));
                     objects.add("/tokens set <player name> <tokens amount>");
-                    commandSender.sendMessage(plugin.messageHandler.useMessage("tokens.errors.invalid-command-correction", objects));
+                    commandSender.sendMessage(plugin.messageHandler.useMessage("tokens.errors.invalid-command.correction", objects));
                 }
             }
             return true;
@@ -153,11 +153,11 @@ public class CommandTokens implements CommandExecutor {
                             objects.add("/tokens remove <player name> <tokens amount>");
                             commandSender.sendMessage(plugin.messageHandler.useMessage("tokens.errors.invalid-command.message", objects));
                         }
-                        if(!plugin.messageHandler.getMessage("tokens.errors.invalid-command-correction").isEmpty()){
+                        if(!plugin.messageHandler.getMessage("tokens.errors.invalid-command.correction").isEmpty()){
                             List<Object> objects = new ArrayList<>();
                             objects.add(new PlayerSender(commandSender));
                             objects.add("/tokens remove <player name> <tokens amount>");
-                            commandSender.sendMessage(plugin.messageHandler.useMessage("tokens.errors.invalid-command-correction", objects));
+                            commandSender.sendMessage(plugin.messageHandler.useMessage("tokens.errors.invalid-command.correction", objects));
                         }
                     }
                 }else return false;
@@ -192,11 +192,11 @@ public class CommandTokens implements CommandExecutor {
                         objects.add("/tokens remove <player name> <tokens amount>");
                         commandSender.sendMessage(plugin.messageHandler.useMessage("tokens.errors.invalid-command.message", objects));
                     }
-                    if(!plugin.messageHandler.getMessage("tokens.errors.invalid-command-correction").isEmpty()){
+                    if(!plugin.messageHandler.getMessage("tokens.errors.invalid-command.correction").isEmpty()){
                         List<Object> objects = new ArrayList<>();
                         objects.add(new PlayerSender(commandSender));
                         objects.add("/tokens remove <player name> <tokens amount>");
-                        commandSender.sendMessage(plugin.messageHandler.useMessage("tokens.errors.invalid-command-correction", objects));
+                        commandSender.sendMessage(plugin.messageHandler.useMessage("tokens.errors.invalid-command.correction", objects));
                     }
                 }
             }
@@ -411,7 +411,7 @@ public class CommandTokens implements CommandExecutor {
 		                List<Object> objects = new ArrayList<>();
 		                objects.add(new PlayerSender((Player)commandSender));
 		                objects.add(ChatColor.AQUA + "/tokens add <player name> <tokens amount>");
-		                commandSender.sendMessage(plugin.messageHandler.useMessage("tokens.errors.invalid-command-correction", objects));
+		                commandSender.sendMessage(plugin.messageHandler.useMessage("tokens.errors.invalid-command.correction", objects));
 		            }
 		        }
 		    }

--- a/src/main/java/net/thirdshift/tokens/commands/tokens/CommandTokens.java
+++ b/src/main/java/net/thirdshift/tokens/commands/tokens/CommandTokens.java
@@ -294,38 +294,7 @@ public class CommandTokens implements CommandExecutor {
         else if ( args[0].equalsIgnoreCase("cache") && 
         		(commandSender.hasPermission("tokens.cache") || commandSender.isOp()) ) {
         	
-        	if ( args.length > 1 && args[1].equalsIgnoreCase("sync") ) {
-                commandSender.sendMessage(plugin.messageHandler.formatMessage("tokens.cache.sync.start.message"));
-                TokenCache.getInstance().submitAsyncSynchronizePlayers( commandSender );
-        	}
-        	else if ( args.length > 2 && args[1].equalsIgnoreCase("stats") && args[2].equalsIgnoreCase("toggle") ) {
-        		TokenCache.getInstance().getStats().setEnabled( !TokenCache.getInstance().getStats().isEnabled() );;
-        		commandSender.sendMessage( plugin.messageHandler.formatMessage("tokens.cache.stats.toggled",
-        				TokenCache.getInstance().getStats().isEnabled()) );
-        	}
-        	else if ( args.length > 2 && args[1].equalsIgnoreCase("stats") && args[2].equalsIgnoreCase("clear") ) {
-        		TokenCache.getInstance().getStats().clear();
-        		commandSender.sendMessage( plugin.messageHandler.formatMessage("tokens.cache.stats.cleared") );
-        	}
-        	else if ( args.length > 2 && args[1].equalsIgnoreCase("stats") && args[2].equalsIgnoreCase("dump") ) {
-        		String playerCacheDump = TokenCache.getInstance().getPlayerDumpStats();
-        		commandSender.sendMessage( playerCacheDump );
-        	}
-        	else if ( args.length > 1 && args[1].equalsIgnoreCase("stats") ) {
-        		commandSender.sendMessage( TokenCache.getInstance().getStats().displayStats() );
-        	}
-        	else {
-                commandSender.sendMessage(ChatColor.GREEN + "===============[ " + ChatColor.GOLD + "Tokens Cache Help " +
-                			ChatColor.BLUE + plugin.getDescription().getVersion() + ChatColor.GREEN + " ]===============");
-                commandSender.sendMessage(ChatColor.AQUA + "/tokens cache help " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-help"));
-                commandSender.sendMessage(ChatColor.AQUA + "/tokens cache sync " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-sync"));
-                commandSender.sendMessage(ChatColor.AQUA + "/tokens cache stats " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-stats"));
-                commandSender.sendMessage(ChatColor.AQUA + "/tokens cache stats toggle " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-stats-toggle"));
-                commandSender.sendMessage(ChatColor.AQUA + "/tokens cache stats clear " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-stats-clear"));
-                commandSender.sendMessage(ChatColor.AQUA + "/tokens cache stats dump " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-stats-dump"));
-
-        	}
-        	return true;
+        	return commandsTokenCache( commandSender, args );
         }
         
         else if(args.length==1) {
@@ -378,6 +347,62 @@ public class CommandTokens implements CommandExecutor {
            return false;
         }
     }
+
+	private boolean commandsTokenCache( CommandSender commandSender, String[] args )
+	{
+		if ( args.length > 1 && args[1].equalsIgnoreCase("sync") ) {
+		    commandSender.sendMessage(plugin.messageHandler.formatMessage("tokens.cache.sync.start.message"));
+		    TokenCache.getInstance().submitAsyncSynchronizePlayers( commandSender );
+		}
+		else if ( args.length > 2 && args[1].equalsIgnoreCase("stats") && args[2].equalsIgnoreCase("toggle") ) {
+			TokenCache.getInstance().getStats().toggleEnabled();;
+			commandSender.sendMessage( plugin.messageHandler.formatMessage("tokens.cache.stats.toggled",
+					TokenCache.getInstance().getStats().isEnabled()) );
+		}
+		else if ( args.length > 2 && args[1].equalsIgnoreCase("stats") && args[2].equalsIgnoreCase("clear") ) {
+			TokenCache.getInstance().getStats().clear();
+			commandSender.sendMessage( plugin.messageHandler.formatMessage("tokens.cache.stats.cleared") );
+		}
+		else if ( args.length > 2 && args[1].equalsIgnoreCase("stats") && args[2].equalsIgnoreCase("dump") ) {
+			String playerCacheDump = TokenCache.getInstance().getPlayerDumpStats();
+			commandSender.sendMessage( playerCacheDump );
+		}
+		else if ( args.length > 2 && args[1].equalsIgnoreCase("stats") && args[2].equalsIgnoreCase("journaling") ) {
+			TokenCache.getInstance().toggleJournal();
+			if ( TokenCache.getInstance().isJournal() ) {
+				commandSender.sendMessage( plugin.messageHandler.formatMessage("tokens.cache.stats.journaling-enbled",
+						TokenCache.getInstance().isJournal()) );
+				if ( args.length > 3 ) {
+					TokenCache.getInstance().setJournalPlayer( args[3] );
+					
+					commandSender.sendMessage( plugin.messageHandler.formatMessage("tokens.cache.stats.journaling-player",
+							TokenCache.getInstance().getJournalPlayer()) );
+				}
+			}
+			else {
+				commandSender.sendMessage( plugin.messageHandler.formatMessage("tokens.cache.stats.journaling-disabled",
+						TokenCache.getInstance().getStats().isEnabled()) );
+				TokenCache.getInstance().setJournalPlayer( null );
+			}
+			
+		}
+		else if ( args.length > 1 && args[1].equalsIgnoreCase("stats") ) {
+			commandSender.sendMessage( TokenCache.getInstance().getStats().displayStats() );
+		}
+		else {
+		    commandSender.sendMessage(ChatColor.GREEN + "===============[ " + ChatColor.GOLD + "Tokens Cache Help " +
+		    			ChatColor.BLUE + plugin.getDescription().getVersion() + ChatColor.GREEN + " ]===============");
+		    commandSender.sendMessage(ChatColor.AQUA + "/tokens cache help " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-help"));
+		    commandSender.sendMessage(ChatColor.AQUA + "/tokens cache sync " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-sync"));
+		    commandSender.sendMessage(ChatColor.AQUA + "/tokens cache stats " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-stats"));
+		    commandSender.sendMessage(ChatColor.AQUA + "/tokens cache stats toggle " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-stats-toggle"));
+		    commandSender.sendMessage(ChatColor.AQUA + "/tokens cache stats clear " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-stats-clear"));
+		    commandSender.sendMessage(ChatColor.AQUA + "/tokens cache stats dump " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-stats-dump"));
+		    commandSender.sendMessage(ChatColor.AQUA + "/tokens cache stats journaling [playerName] " + plugin.messageHandler.formatMessage("tokens.cache.menu.help-stats-journaling"));
+
+		}
+		return true;
+	}
 
 	private void commandAdd( CommandSender commandSender, String[] args )
 	{

--- a/src/main/java/net/thirdshift/tokens/database/mysql/MySQLHandler.java
+++ b/src/main/java/net/thirdshift/tokens/database/mysql/MySQLHandler.java
@@ -84,7 +84,7 @@ public class MySQLHandler {
          }
     }
 
-    public void stopSQLConnection() {
+    public void closeConnection() {
         try {
             if (connection!=null && !connection.isClosed()){
                 connection.close();

--- a/src/main/java/net/thirdshift/tokens/database/mysql/MySQLHandler.java
+++ b/src/main/java/net/thirdshift/tokens/database/mysql/MySQLHandler.java
@@ -72,7 +72,7 @@ public class MySQLHandler {
     
     private void createTable() {
     	 String table ="CREATE TABLE IF NOT EXISTS tokens " +
-         		"(uuid VARCHAR(40) NOT NULL, num INT(9) NOT NULL, UNIQUE (uuid));";
+         		"(uuid VARCHAR(40) NOT NULL, num INT(11) NOT NULL, UNIQUE (uuid));";
          
          try ( PreparedStatement stmt = connection.prepareStatement(table); ) {
          	stmt.executeUpdate();

--- a/src/main/java/net/thirdshift/tokens/database/sqllite/SQLLite.java
+++ b/src/main/java/net/thirdshift/tokens/database/sqllite/SQLLite.java
@@ -48,7 +48,9 @@ public class SQLLite extends Database{
 //    }
 
     @Override
-    protected void openConnection() {
+    protected boolean openConnection() {
+    	boolean results = false;
+    	
         File storageFolder = new File(getPlugin().getDataFolder(), "Storage");
         if (!storageFolder.exists()){
             if(storageFolder.mkdirs())
@@ -71,6 +73,7 @@ public class SQLLite extends Database{
         try {
             Class.forName("org.sqlite.JDBC");
             setConnection( DriverManager.getConnection("jdbc:sqlite:" + dataFolder) );
+            results = true;
         } 
         catch (SQLException ex) {
         	getPlugin().getLogger().log(Level.SEVERE,
@@ -81,6 +84,7 @@ public class SQLLite extends Database{
             		"SQLite openConnection: The SQLite JDBC Driver was not found. " +
             		"You need the SQLite JBDC library. Google it. Put it in /lib folder.");
         }
+        return results;
     }
     
     public void load() {

--- a/src/main/java/net/thirdshift/tokens/database/sqllite/SQLLite.java
+++ b/src/main/java/net/thirdshift/tokens/database/sqllite/SQLLite.java
@@ -91,7 +91,7 @@ public class SQLLite extends Database{
         try ( Statement s = getSQLConnection().createStatement(); ) {
             String sql = 
             		"CREATE TABLE IF NOT EXISTS tokens_table " +
-            		"(`player` varchar(32) NOT NULL,`tokens` int(11) NOT NULL, PRIMARY KEY (`player`));";
+            		"(`player` varchar(40) NOT NULL,`tokens` int(11) NOT NULL, PRIMARY KEY (`player`));";
             s.executeUpdate(sql);
         } 
         catch (SQLException e) {

--- a/src/main/java/net/thirdshift/tokens/messages/Message.java
+++ b/src/main/java/net/thirdshift/tokens/messages/Message.java
@@ -70,5 +70,9 @@ public class Message {
     public String getRaw() {
         return raw;
     }
+    
+    public String getFormatted() {
+    	return formatted;
+    }
 
 }

--- a/src/main/java/net/thirdshift/tokens/messages/MessageHandler.java
+++ b/src/main/java/net/thirdshift/tokens/messages/MessageHandler.java
@@ -21,8 +21,21 @@ public class MessageHandler {
 
     public Message getMessage(String path){ return messageList.get(path); }
 
+    /**
+     * <p>Uses the give message, but if the path does not exist, then it returns
+     * an empty String so it does not generate a NullPointerException.
+     * </p>
+     * 
+     * @param path
+     * @param objectList
+     * @return
+     */
     public String useMessage(String path, List<Object> objectList){
-        return messageList.get(path).use(objectList);
+    	String results = null;
+    	if ( messageList.containsKey( path ) ) {
+    		results = messageList.get(path).use(objectList);
+    	}
+        return results == null ? "" : results;
     }
 
     /**

--- a/src/main/java/net/thirdshift/tokens/messages/MessageHandler.java
+++ b/src/main/java/net/thirdshift/tokens/messages/MessageHandler.java
@@ -91,8 +91,13 @@ public class MessageHandler {
         paths.add("tokens.cache.menu.help-help");
         paths.add("tokens.cache.menu.help-sync");
         paths.add("tokens.cache.menu.help-stats");
+        paths.add("tokens.cache.menu.help-stats-toggle");
+        paths.add("tokens.cache.menu.help-stats-clear");
+        paths.add("tokens.cache.menu.help-stats-dump");
         paths.add("tokens.cache.sync.start.message");
         paths.add("tokens.cache.sync.completed.message");
+        paths.add("tokens.cache.stats.toggled");
+        paths.add("tokens.cache.stats.cleared");
         
         
         // Start redeem

--- a/src/main/java/net/thirdshift/tokens/messages/MessageHandler.java
+++ b/src/main/java/net/thirdshift/tokens/messages/MessageHandler.java
@@ -94,10 +94,14 @@ public class MessageHandler {
         paths.add("tokens.cache.menu.help-stats-toggle");
         paths.add("tokens.cache.menu.help-stats-clear");
         paths.add("tokens.cache.menu.help-stats-dump");
+        paths.add("tokens.cache.menu.help-stats-journaling");
         paths.add("tokens.cache.sync.start.message");
         paths.add("tokens.cache.sync.completed.message");
         paths.add("tokens.cache.stats.toggled");
         paths.add("tokens.cache.stats.cleared");
+        paths.add("tokens.cache.stats.journaling-enbled");
+        paths.add("tokens.cache.stats.journaling-player");
+        paths.add("tokens.cache.stats.journaling-disabled");
         
         
         // Start redeem

--- a/src/main/java/net/thirdshift/tokens/messages/MessageHandler.java
+++ b/src/main/java/net/thirdshift/tokens/messages/MessageHandler.java
@@ -25,6 +25,27 @@ public class MessageHandler {
         return messageList.get(path).use(objectList);
     }
 
+    /**
+     * <p>This uses the String.format() to apply parameters to the given message.
+     * </p>
+     * 
+     * @param path
+     * @param args Arguments to be applied to the String.format(). Does not support the placeholders.
+     * @return
+     */
+    public String formatMessage(String path, Object... args) {
+    	String formatted = null;
+    	if ( messageList.containsKey(path) ) {
+    		String message = messageList.get(path).getFormatted();
+    		formatted = String.format( message, args );
+    	}
+    	else {
+    		formatted = "Tokens message failure: Could not find message path: " + path + 
+					" Please report to an admin and have them check token's message file.";
+    	}
+    	return formatted;
+    }
+    
     public void loadMessages(){
         this.messageConfig=plugin.getMessageConfig();
         if(messageList!=null){
@@ -34,6 +55,7 @@ public class MessageHandler {
         List<String> paths = new ArrayList<>();
         paths.add("tokens.main");
         paths.add("tokens.others");
+        paths.add("tokens.console");
 
         paths.add("tokens.add.sender");
         paths.add("tokens.add.receiver");
@@ -51,6 +73,15 @@ public class MessageHandler {
         paths.add("tokens.errors.invalid-command.message");
         paths.add("tokens.errors.invalid-command.correction");
 
+        
+        // Token Cache messages:
+        paths.add("tokens.cache.menu.help-help");
+        paths.add("tokens.cache.menu.help-sync");
+        paths.add("tokens.cache.menu.help-stats");
+        paths.add("tokens.cache.sync.start.message");
+        paths.add("tokens.cache.sync.completed.message");
+        
+        
         // Start redeem
         paths.add("redeem.mcmmo.redeemed");
         paths.add("redeem.mcmmo.invalid-skill");

--- a/src/main/java/net/thirdshift/tokens/util/TokensConfigHandler.java
+++ b/src/main/java/net/thirdshift/tokens/util/TokensConfigHandler.java
@@ -75,7 +75,7 @@ public class TokensConfigHandler {
 			plugin.getLogger().info("Storage Type: SQLLite | [ MySQL ]");
 		} else {
 			if(plugin.getMySQL()!=null){
-				plugin.getMySQL().stopSQLConnection();
+				plugin.getMySQL().closeConnection();
 				plugin.nullMySQL();
 			}
 			isRunningMySQL = false;

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -35,12 +35,18 @@ tokens:
     menu:
       help-help: "&7Displays this helpful cache text"
       help-sync: "&7Synchronizes the cache with the database. Purge non-active players."
-      help-stats: "&7Token Cache stats"
+      help-stats: "&7Token Cache stats - Displays collected stats"
+      help-stats-toggle: "&7Token Cache stats - Toggle on and off"
+      help-stats-clear: "&7Token Cache Stats - Clear & reset the stats. If off, it will not start the stats."
+      help-stats-dump: "&7Token Cache Stats Dump - Dumps the player cache and shows internal stats."
     sync:
       start:
         message: "&7Starting Token Cache database synchronization..."
       completed:
-        message: "&7Finished Token Cache database synchronization: cached players= %d  unloaded players= %d  players syncronized= %d"
+        message: "&7Finished synchronization: cached players= %d  unloaded players= %d  players synchronized= %d"
+    stats:
+      toggled: "&7Token Cache stats toggled. enabled= &5%b"
+      cleared: "&7Token Cache stats have been cleared & reset."
 redeem:
   mcmmo:
     redeemed: "&7You redeemed &6%tokens% &7Tokens for the skill &8%skill_name%"

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -13,6 +13,7 @@
 tokens:
   main: "&7You have &6%tokens% &7Tokens"
   others: "&e%target% &7has &6%tokens% &7Tokens"
+  console: "&7You cannot run this command from console."
   add:
     sender: "&7You added &6%tokens% &7Tokens to %target%&7's Tokens."
     receiver: "" # I left this blank so the player doesn't know who added the Tokens.
@@ -30,6 +31,16 @@ tokens:
     invalid-command:
       message: "&4Invalid command use."
       correction: "&7Command usage: %command_usage%"
+  cache:
+    menu:
+      help-help: "&7Displays this helpful cache text"
+      help-sync: "&7Synchronizes the cache with the database. Purge non-active players."
+      help-stats: "&7Token Cache stats"
+    sync:
+      start:
+        message: "&7Starting Token Cache database synchronization..."
+      completed:
+        message: "&7Finished Token Cache database synchronization: cached players= %d  unloaded players= %d  players updated= %d  players syncronized= %d"
 redeem:
   mcmmo:
     redeemed: "&7You redeemed &6%tokens% &7Tokens for the skill &8%skill_name%"

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -39,14 +39,18 @@ tokens:
       help-stats-toggle: "&7Token Cache stats - Toggle on and off"
       help-stats-clear: "&7Token Cache Stats - Clear & reset the stats. If off, it will not start the stats."
       help-stats-dump: "&7Token Cache Stats Dump - Dumps the player cache and shows internal stats."
+      help-stats-journaling: "&7Token Cache Stats Journaling - Toggle on and off. Player name is optional."
     sync:
       start:
         message: "&7Starting Token Cache database synchronization..."
       completed:
-        message: "&7Finished synchronization: cached players= %d  unloaded players= %d  players synchronized= %d"
+        message: "&7Finished synchronization: %d players in cache. Unloaded %d players. %d players synchronized. %d players were saved to DB."
     stats:
       toggled: "&7Token Cache stats toggled. enabled= &5%b"
       cleared: "&7Token Cache stats have been cleared & reset."
+      journaling-enbled: "&Token Cache Journaling has been enabled."
+      journaling-player: "&Token Cache Journaling is activated on player: %s."
+      journaling-disabled: "&Token Cache Journaling has been disabled."
 redeem:
   mcmmo:
     redeemed: "&7You redeemed &6%tokens% &7Tokens for the skill &8%skill_name%"

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -40,7 +40,7 @@ tokens:
       start:
         message: "&7Starting Token Cache database synchronization..."
       completed:
-        message: "&7Finished Token Cache database synchronization: cached players= %d  unloaded players= %d  players updated= %d  players syncronized= %d"
+        message: "&7Finished Token Cache database synchronization: cached players= %d  unloaded players= %d  players syncronized= %d"
 redeem:
   mcmmo:
     redeemed: "&7You redeemed &6%tokens% &7Tokens for the skill &8%skill_name%"


### PR DESCRIPTION
This cache sits between the core Token plugin and the database interfaces and provides a significant improvement in performance. If the cache is disabled, then all transactions will directly pass through the cache to the database and will behave as Tokens was prior to the addition of the cache.  The cache could possibly be turned on and off rapidly without loss of data, even under heavy use; its not recommended to do this, but it should minimize risks.  When the cache is enabled, all transactions interface with the cache and provides a rapid response without hitting the database, which is critical when the Tokens is called within the bukkit main thread. 

This cache was designed for situations where multiple players will be hitting Tokens hundreds of times per minute, but even occasional hits on Tokens will greatly improve performance by ensuring all database access is through an asynchronous task.

The way it operates is by preloading database content of the players that are online.  Then when Tokens tries to access the database, it instead deals with the Cache.  For reads, such as getTokens() nothing needs to be written back to the database.  If the database needs to be changed, then the transaction is recorded within the cache, and an asynchronous task is submitted to run in 10 seconds.  The delay allows more updates to the cache so the database write will be more effective in reducing database I/O.  

Transactions have been minimized in number, to simplify the database interface.  For example, Tokens has two functions, addTokens() and removeTokens().  Through the cache, both use the same cache interface, addTokens() where calls through removeTokens() just negates the token amount.  Likewise, setTokens also uses addTokens() so as to allow the database transaction to be delayed.  If it were not "converted" to an addTokens() call, then everything would have to block to directly sync with the database to ensure the cache is able to maintain synchronization. As a result, all cache updates to the database can utilize the relational database's addTokens which "preserves" any changes that could have been made by a third party app.  So even if the cache is out of sync with the database, no data will be lost.  Under normal conditions cache data will continue to be written to the database, without loss, but the cache can be synchronized manually via a /tokens cache sync command.  If it's not sync'd no data will be lost and the next time tokens is loaded it will reflect the correct value.  

The cache maintains three values.  One value represents what "should" be in the database (valueDB).  One represents what needs to be "added" (valueUncommitted) to the database (negative values are valid).  The third value is a transition value (valueTransition), which is perhaps the most critical value to reducing blocking.  How these three values work, is when a value is added to the cache, it triggers an update task to run in the future.  When that job actually runs, it locks valueUncommited, copies its value to valueTransition, then zeros valueUncommitted, then releases the lock.  This ensures any process that is trying to add to the cache experiences the shortest possible blocking. Once the locks have been released on valueUncommitted and valueTransition, it then accesses the database, applying the contents of valueTransition.  When that is complete, a lock is placed on valueDB and valueTransition to update the valueDB to match the database's value, then zeros valueTransition.  If at the end of the asynchronous update there is a non-zero value within valueUncommited, a new asyc task will be submitted to run in the future.  So with the default settings, even under very heavy loads, the player's data is written to the database about every 10 seconds.  The delay time can easily be extended to reduce database activity even more, which could be beneficial in heavy loaded systems.

Upon server shutdown, the cache is disabled so all transaction will pass through the cache instantly, but then the player cache in memory will be unloaded.  Any unsaved values will then be applied to the database to ensure no cache data is lost.  When a player leaves the sever, the same process is used to unload the player's data from the cache.

New commands have been added to support the cache: /tokens cache provides a listing of the sub commands.  In the cache, it has support for basic stats (with low overhead if enabled) and journaling (detailed transactions written to the log) for all transactions within Tokens, or targeted to a specific player.  Stats and journaling can provide simple checks/monitoring to see how the cache is working.

Fixed a few other issues with a few other commands, but not all of them.  

This has gone under a few days of testing and is working really well.